### PR TITLE
Tutorial to use docker-dehydrated without any configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,11 @@
 
 This is a docker container that wraps around [dehydrated](https://github.com/lukas2511/dehydrated).
 
+## Usage
+
+For a short tutorial on how to use this container with zero-configuration to sign certificates
+using the HTTP-Challenge, see [zero-config-mode.md]("Zero-Config"-Mode).
+
 ## Environment variables
 
 The following environment variables can be set to influence the container's behaviour:
@@ -16,3 +21,4 @@ If the environment variables were not explicitely set, no modification to the co
 When the container is started, a script is run which looks for the configuration file in the places supported by dehydrated,
 and if no configuration file is found, it will copy the [example configuration file](https://github.com/lukas2511/dehydrated/docs/examples/config)
 into `/etc/dehydrated/config`.
+

--- a/zero-config-mode.md
+++ b/zero-config-mode.md
@@ -1,0 +1,42 @@
+# Zero-configuration mode
+
+This is a tutorial on how to use this container (without needing to configure anything) to create
+certificates for a given set of domains (using the HTTP-Challenge).
+
+## Prerequisites
+
+These are the things that you need to setup / already have set up in order to use this container
+for creating certificates using the HTTP-Challenge:
+
+- A working internet connection, obviously
+- HTTP Webserver to serve the ``.well-known`` which is used for the HTTP-Challenge
+
+Now create a folder in which dehydrated can push the challenge-data later, in this tutorial it
+will be called ``dehydrated-www``. Configure your Webserver to serve the contents of this folder
+under ``domain``/.well-known/ (for all domains which you want to create certificates for).
+
+Next create another folder in which dehydrated will place its configuration, certificates etc.,
+in this tutorial it will be called ``dehydrated-data``. In this folder, create a file called
+``domains.txt`` in which you list the domains you want to create certificates for, using the
+following format:
+
+- each domain on a new line
+- subdomains of a domain on the same line as the domain.
+
+For more information on the format, see [https://github.com/lukas2511/dehydrated/blob/master/docs/domains_txt.md](https://github.com/lukas2511/dehydrated/blob/master/docs/domains_txt.md)
+
+## Using docker-dehydrated
+
+Now you can just run the container, and as the default challenge is the HTTP-Challenge, you do
+not need to pass environment variables to alter the default behaviour. To run the container,
+execute:
+
+```bash
+$ docker run -v ./dehydrated-www:/var/www/dehydrated -v ./dehydrated-data:/etc/dehydrated jcgruenhage/dehydrated
+```
+
+Please note that on SELinux-Systems, you need to set the "SELinux"-Flag when passing volumes:
+``./dehydrated-www:/var/www/dehydrated:z`` (analog for ``dehydrated-data``).
+
+Also, the container will ``chown`` the folders passed to himself, so make sure your webserver can
+still server the contents of ``dehydrated-www``.

--- a/zero-config-mode.md
+++ b/zero-config-mode.md
@@ -13,7 +13,7 @@ for creating certificates using the HTTP-Challenge:
 
 Now create a folder in which dehydrated can push the challenge-data later, in this tutorial it
 will be called ``dehydrated-www``. Configure your Webserver to serve the contents of this folder
-under ``domain``/.well-known/ (for all domains which you want to create certificates for).
+under ``domain``/.well-known/ (for all domains for which you want to create certificates).
 
 Next create another folder in which dehydrated will place its configuration, certificates etc.,
 in this tutorial it will be called ``dehydrated-data``. In this folder, create a file called
@@ -32,11 +32,15 @@ not need to pass environment variables to alter the default behaviour. To run th
 execute:
 
 ```bash
-$ docker run -v ./dehydrated-www:/var/www/dehydrated -v ./dehydrated-data:/etc/dehydrated jcgruenhage/dehydrated
+$ docker run -v ./dehydrated-www:/var/www/dehydrated \
+-v ./dehydrated-data:/etc/dehydrated jcgruenhage/dehydrated
 ```
 
 Please note that on SELinux-Systems, you need to set the "SELinux"-Flag when passing volumes:
 ``./dehydrated-www:/var/www/dehydrated:z`` (analog for ``dehydrated-data``).
 
 Also, the container will ``chown`` the folders passed to himself, so make sure your webserver can
-still server the contents of ``dehydrated-www``.
+still serve the contents of ``dehydrated-www``.
+
+After the challenges have been run, the certificates will be stored in ``dehydrated-data/certs``,
+make sure to back this folder up!


### PR DESCRIPTION
Adds documentation on how to use this container to create certificates without needing to configure anything in the container. This so-called "zero-config"-tutorial is also linked in the README.